### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/amplify/backend/auth/awsalexaui51864c6a/awsalexaui51864c6a-cloudformation-template.yml
+++ b/amplify/backend/auth/awsalexaui51864c6a/awsalexaui51864c6a-cloudformation-template.yml
@@ -250,7 +250,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
